### PR TITLE
Cleanup geoserver docker build

### DIFF
--- a/geodocker-geoserver/Dockerfile.template
+++ b/geodocker-geoserver/Dockerfile.template
@@ -1,13 +1,3 @@
-FROM centos:7
-ARG GEOMESA_VERSION
-COPY tarballs/geomesa-accumulo-dist_2.11-${GEOMESA_VERSION}-bin.tar.gz accumulo-dist.tar.gz
-RUN tar -zxf accumulo-dist.tar.gz
-
-FROM centos:7
-ARG GEOMESA_VERSION
-COPY tarballs/geomesa-kafka-dist_2.11-${GEOMESA_VERSION}-bin.tar.gz kafka-dist.tar.gz
-RUN tar -zxf kafka-dist.tar.gz
-
 FROM quay.io/geomesa/base:__TAG__
 ARG GEOMESA_VERSION
 ARG ACCUMULO_VERSION
@@ -40,46 +30,46 @@ RUN set -x \
   && rm -rf /tmp/geoserver-wps.zip
 
 # Install Geomesa Accumulo Distribution
-COPY --from=0 /geomesa-accumulo* /opt/geomesa/
+ADD tarballs/geomesa-accumulo-dist_2.11-${GEOMESA_VERSION}-bin.tar.gz /opt/
   
 # Install GeoMesa Accumulo DataStore
 RUN set -x \
     && cd /opt/tomcat/webapps/geoserver/WEB-INF/lib/ \
-    && tar zxvf /opt/geomesa/dist/gs-plugins/geomesa-accumulo-gs-plugin_2.11-${GEOMESA_VERSION}-install.tar.gz
+    && tar zxvf /opt/geomesa-accumulo_2.11-${GEOMESA_VERSION}/dist/gs-plugins/geomesa-accumulo-gs-plugin_2.11-${GEOMESA_VERSION}-install.tar.gz
 
 # Install GeoMesa Accumulo BlobStore
 RUN set -x \
     && cd /opt/tomcat/webapps/geoserver/WEB-INF/lib/ \
-    && tar zxvf /opt/geomesa/dist/gs-plugins/geomesa-blobstore-gs-plugin_2.11-${GEOMESA_VERSION}-install.tar.gz
+    && tar zxvf /opt/geomesa-accumulo_2.11-${GEOMESA_VERSION}/dist/gs-plugins/geomesa-blobstore-gs-plugin_2.11-${GEOMESA_VERSION}-install.tar.gz
 
 # Install GeoMesa Stream Store
 RUN set -x \
     && cd /opt/tomcat/webapps/geoserver/WEB-INF/lib/ \
-    && tar zxvf /opt/geomesa/dist/gs-plugins/geomesa-stream-gs-plugin_2.11-${GEOMESA_VERSION}-install.tar.gz
+    && tar zxvf /opt/geomesa-accumulo_2.11-${GEOMESA_VERSION}/dist/gs-plugins/geomesa-stream-gs-plugin_2.11-${GEOMESA_VERSION}-install.tar.gz
 
 # Install GeoMesa GeoJson Support
 RUN set -x \
     && cd /opt/tomcat/webapps/geoserver/WEB-INF/lib/ \
-    && tar zxvf /opt/geomesa/dist/gs-plugins/geomesa-geojson-gs-plugin_2.11-${GEOMESA_VERSION}-install.tar.gz
+    && tar zxvf /opt/geomesa-accumulo_2.11-${GEOMESA_VERSION}/dist/gs-plugins/geomesa-geojson-gs-plugin_2.11-${GEOMESA_VERSION}-install.tar.gz
 
 # Install GeoMesa Process Jar
 RUN set -x \
     && cd /opt/tomcat/webapps/geoserver/WEB-INF/lib/ \
-    && cp /opt/geomesa/dist/gs-plugins/geomesa-process-wps_2.11-${GEOMESA_VERSION}.jar .
+    && cp /opt/geomesa-accumulo_2.11-${GEOMESA_VERSION}/dist/gs-plugins/geomesa-process-wps_2.11-${GEOMESA_VERSION}.jar .
 
 # Install Hadoop and Accumulo specific jars
 RUN set -x \
-    && /opt/geomesa/bin/install-hadoop-accumulo.sh /opt/tomcat/webapps/geoserver/WEB-INF/lib -a ${ACCUMULO_VERSION} -h ${HADOOP_VERSION} -t ${THRIFT_VERSION}
+    && /opt/geomesa-accumulo_2.11-${GEOMESA_VERSION}/bin/install-hadoop-accumulo.sh /opt/tomcat/webapps/geoserver/WEB-INF/lib -a ${ACCUMULO_VERSION} -h ${HADOOP_VERSION} -t ${THRIFT_VERSION}
 
 # Install Geomesa Kafka Distribution
-COPY --from=1 /geomesa-kafka* /opt/geomesa-kafka/
+ADD tarballs/geomesa-kafka-dist_2.11-${GEOMESA_VERSION}-bin.tar.gz /opt/
 
 # Install GeoMesa Kafka DataStore
 RUN set -x \
   && cd /opt/tomcat/webapps/geoserver/WEB-INF/lib/ \
-  && tar zxvf /opt/geomesa-kafka/dist/gs-plugins/geomesa-kafka-gs-plugin_2.11-${GEOMESA_VERSION}-install.tar.gz \
+  && tar zxvf /opt/geomesa-kafka_2.11-${GEOMESA_VERSION}/dist/gs-plugins/geomesa-kafka-gs-plugin_2.11-${GEOMESA_VERSION}-install.tar.gz \
   && rm /opt/tomcat/webapps/geoserver/WEB-INF/lib/zookeeper*.jar \
-  && /opt/geomesa-kafka/bin/install-kafka.sh /opt/tomcat/webapps/geoserver/WEB-INF/lib
+  && /opt/geomesa-kafka_2.11-${GEOMESA_VERSION}/bin/install-kafka.sh /opt/tomcat/webapps/geoserver/WEB-INF/lib
 
 
 FROM quay.io/geomesa/base:__TAG__
@@ -96,7 +86,7 @@ ENV GEOSERVER_VERSION 2.12.0
 ENV TOMCAT_VERSION 8.5.23
 ENV CATALINA_OPTS "-Xmx8g -XX:MaxPermSize=512M -Duser.timezone=UTC -server -Djava.awt.headless=true"
 
-COPY --from=2 /opt/tomcat /opt/tomcat/
+COPY --from=0 /opt/tomcat /opt/tomcat/
 RUN set -x \
   && groupadd tomcat \
   && useradd -M -s /bin/nologin -g tomcat -d /opt/tomcat tomcat \

--- a/geodocker-geoserver/Makefile
+++ b/geodocker-geoserver/Makefile
@@ -6,12 +6,12 @@ GEOMESA_VERSION := 2.1.0
 ACCUMULO_VERSION := 1.9.2
 THRIFT_VERSION := 0.9.3
 TAG := geomesa-${GEOMESA_VERSION}-accumulo-${ACCUMULO_VERSION}
-GEOMESA_ACCUMULO_TARBALL := geomesa-accumulo-dist_2.11-${GEOMESA_VERSION}-bin.tar.gz
-GEOMESA_ACCUMULO_GS_INSTALL := geomesa-accumulo-gs-plugin_2.11-${GEOMESA_VERSION}-install.tar.gz
-GEOMESA_KAFKA_TARBALL := geomesa-kafka-dist_2.11-${GEOMESA_VERSION}-bin.tar.gz
-GEOMESA_KAFKA_GS_INSTALL := geomesa-kafka-gs-plugin_2.11-${GEOMESA_VERSION}-install.tar.gz
+GEOMESA_ACCUMULO_DIST := geomesa-accumulo-dist_2.11-${GEOMESA_VERSION}-bin.tar.gz
+GEOMESA_ACCUMULO_TARBALL := tarballs/${GEOMESA_ACCUMULO_DIST}
+GEOMESA_KAFKA_DIST := geomesa-kafka-dist_2.11-${GEOMESA_VERSION}-bin.tar.gz
+GEOMESA_KAFKA_TARBALL := tarballs/${GEOMESA_KAFKA_DIST}
 
-build: tarball dockerfile
+build: ${GEOMESA_ACCUMULO_TARBALL} ${GEOMESA_KAFKA_TARBALL} dockerfile
 	docker build \
                 --build-arg GEOMESA_VERSION=${GEOMESA_VERSION} \
                 --build-arg ACCUMULO_VERSION=${ACCUMULO_VERSION} \
@@ -23,10 +23,13 @@ dockerfile:
 	mkdir -p target
 	sed 's/__TAG__/'"${TAG}"'/' Dockerfile.template > target/Dockerfile
 
-tarball:
+${GEOMESA_ACCUMULO_TARBALL}:
 	mkdir -p tarballs
-	cp ${HOME}/.m2/repository/org/locationtech/geomesa/geomesa-accumulo-dist_2.11/${GEOMESA_VERSION}/${GEOMESA_ACCUMULO_TARBALL} tarballs/.
-	cp ${HOME}/.m2/repository/org/locationtech/geomesa/geomesa-kafka-dist_2.11/${GEOMESA_VERSION}/${GEOMESA_KAFKA_TARBALL} tarballs/.
+	cp ${HOME}/.m2/repository/org/locationtech/geomesa/geomesa-accumulo-dist_2.11/${GEOMESA_VERSION}/${GEOMESA_ACCUMULO_DIST} tarballs/.
+
+${GEOMESA_KAFKA_TARBALL}:
+	mkdir -p tarballs
+	cp ${HOME}/.m2/repository/org/locationtech/geomesa/geomesa-kafka-dist_2.11/${GEOMESA_VERSION}/${GEOMESA_KAFKA_DIST} tarballs/.
 
 publish: build
 	docker push ${IMG}:${TAG}


### PR DESCRIPTION
Some minor changes to the geoserver build process. No functional changes to the resulting docker image.

Three main changes are made:
- removing two of the build stages that are unnecessary and possibly confusing
- unpacking the geomesa accumulo and kafka distribution tar files with docker's `ADD` command, rather than `COPY` and `RUN tar...` commands
- refactoring geodocker-geoserver/Makefile to make it more consistent with geodocker-accumulo-geomesa/Makefile
