### PR TITLE
Fixes clashing jars in output path (from war)

### DIFF
--- a/geodocker-geoserver/Dockerfile.template
+++ b/geodocker-geoserver/Dockerfile.template
@@ -36,7 +36,7 @@ RUN set -x \
 RUN set -x \
   && curl -sS -L -o /tmp/geoserver-wps.zip \
     https://downloads.sourceforge.net/project/geoserver/GeoServer/${GEOSERVER_VERSION}/extensions/geoserver-${GEOSERVER_VERSION}-wps-plugin.zip \
-  && unzip -j /tmp/geoserver-wps.zip -d /opt/tomcat/webapps/geoserver/WEB-INF/lib/ \
+  && (echo 'A' | unzip -j /tmp/geoserver-wps.zip -d /opt/tomcat/webapps/geoserver/WEB-INF/lib/) \
   && rm -rf /tmp/geoserver-wps.zip
 
 # Install Geomesa Accumulo Distribution


### PR DESCRIPTION
Also you need to fix /etc/yum.repos.d/bigtop.repo the current curl request from /base returns error:
File contains no section headers.
file: file:///etc/yum.repos.d/bigtop.repo, line: 1
`'<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">\n'` 
(the request doesn't correctly unpack the http body)

I just copied the URL content body directy into a file in my Docker-dir